### PR TITLE
Fix X/Y button swap in SDL2/Steam by using kernel's Nintendo-conventi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,8 +429,8 @@ echo 'uinput' | sudo tee /etc/modules-load.d/uinput.conf
 |---|---|---|
 | A | BTN_SOUTH (0x130) | BTN_SOUTH (0x130) |
 | B | BTN_EAST (0x131) | BTN_EAST (0x131) |
-| X | BTN_C (0x132) | BTN_WEST (0x134) |
-| Y | BTN_NORTH (0x133) | BTN_NORTH (0x133) |
+| X | BTN_C (0x132) | BTN_NORTH (0x133) — kernel alias BTN_X |
+| Y | BTN_NORTH (0x133) | BTN_WEST (0x134) — kernel alias BTN_Y |
 | LB (Left Bumper) | BTN_WEST (0x134) | BTN_TL (0x136) |
 | RB (Right Bumper) | BTN_Z (0x135) | BTN_TR (0x137) |
 | Select / Back | BTN_TL (0x136) | BTN_SELECT (0x13a) |

--- a/scuf_envision/constants.py
+++ b/scuf_envision/constants.py
@@ -29,8 +29,8 @@ SCUF_PRODUCT_ID_RECEIVER = 0x3A09  # SCUF Envision Pro Wireless USB Receiver V2
 BUTTON_MAP = {
     ecodes.BTN_SOUTH:          ecodes.BTN_SOUTH,          # A -> A
     ecodes.BTN_EAST:           ecodes.BTN_EAST,           # B -> B
-    ecodes.BTN_C:              ecodes.BTN_WEST,           # SCUF sends BTN_C for X
-    ecodes.BTN_NORTH:          ecodes.BTN_NORTH,          # Y -> Y
+    ecodes.BTN_C:              ecodes.BTN_NORTH,          # SCUF sends BTN_C for X -> BTN_NORTH (kernel: BTN_X=BTN_NORTH)
+    ecodes.BTN_NORTH:          ecodes.BTN_WEST,           # Y -> BTN_WEST (kernel: BTN_Y=BTN_WEST)
     ecodes.BTN_WEST:           ecodes.BTN_TL,             # SCUF sends BTN_WEST for LB
     ecodes.BTN_Z:              ecodes.BTN_TR,             # SCUF sends BTN_Z for RB
     ecodes.BTN_TL:             ecodes.BTN_SELECT,         # SCUF sends BTN_TL for Select/Back

--- a/tools/diag.py
+++ b/tools/diag.py
@@ -25,8 +25,8 @@ from scuf_envision.constants import BUTTON_MAP, AXIS_MAP, SCUF_VENDOR_ID, SCUF_P
 SCUF_BUTTON_NAMES = {
     ecodes.BTN_SOUTH: "A (BTN_SOUTH)",
     ecodes.BTN_EAST:  "B (BTN_EAST)",
-    ecodes.BTN_C:     "X (BTN_C) -> should be BTN_WEST",
-    ecodes.BTN_NORTH: "Y (BTN_NORTH)",
+    ecodes.BTN_C:     "X (BTN_C) -> should be BTN_NORTH (BTN_X)",
+    ecodes.BTN_NORTH: "Y (BTN_NORTH) -> should be BTN_WEST (BTN_Y)",
     ecodes.BTN_WEST:  "LB (BTN_WEST) -> should be BTN_TL",
     ecodes.BTN_Z:     "RB (BTN_Z) -> should be BTN_TR",
     ecodes.BTN_TL:    "Select/Back (BTN_TL)",


### PR DESCRIPTION
…on aliases

The Linux kernel defines BTN_X=BTN_NORTH (0x133) and BTN_Y=BTN_WEST (0x134), following SNES/Nintendo positional layout. SDL2 assigns button indices by code order (BTN_NORTH→index 2→SDL X, BTN_WEST→index 3→SDL Y). Our previous mapping used Xbox positional logic (X=West, Y=North), which was correct for evtest but caused X/Y to appear swapped in SDL2-based applications (Steam, PPSSPP, Heroic).

Swap the output codes so physical X → BTN_NORTH (kernel BTN_X) and physical Y → BTN_WEST (kernel BTN_Y), fixing games while remaining correct in evtest.

https://claude.ai/code/session_01FVu1QqRTjZ8sDF8WYbJEdy