### PR TITLE
Add startup retry loop for device enumeration delay

### DIFF
--- a/scuf_envision/bridge.py
+++ b/scuf_envision/bridge.py
@@ -21,7 +21,7 @@ from evdev import ecodes
 from .constants import (
     BUTTON_MAP, PADDLE_MAP, AXIS_MAP, POLL_TIMEOUT_MS,
 )
-from .discovery import DiscoveredDevice, discover_scuf
+from .discovery import DiscoveredDevice, discover_scuf, discover_scuf_with_retry
 from .input_filter import InputFilter
 from .virtual_gamepad import VirtualGamepad
 
@@ -284,9 +284,9 @@ def run():
 
     log.info("SCUF Envision Pro V2 Linux Driver starting...")
 
-    discovered = discover_scuf()
+    discovered = discover_scuf_with_retry()
     if discovered is None:
-        log.error("No SCUF Envision Pro V2 controller found!")
+        log.error("No SCUF Envision Pro V2 controller found after 30s!")
         log.error("Make sure the controller is plugged in via USB or wireless receiver is connected.")
         log.error("Check: lsusb | grep 1b1c")
         sys.exit(1)

--- a/tools/diag.py
+++ b/tools/diag.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import evdev
 from evdev import ecodes, categorize
-from scuf_envision.discovery import discover_scuf, _get_vid_pid, _has_joystick_handler, _event_number
+from scuf_envision.discovery import discover_scuf, discover_scuf_with_retry, _get_vid_pid, _has_joystick_handler, _event_number
 from scuf_envision.constants import BUTTON_MAP, AXIS_MAP, SCUF_VENDOR_ID, SCUF_PRODUCT_ID_WIRED, SCUF_PRODUCT_ID_RECEIVER
 
 # Human-readable names for the SCUF's actual physical buttons
@@ -167,10 +167,10 @@ def main():
     print("-" * 60)
     print()
 
-    discovered = discover_scuf()
+    discovered = discover_scuf_with_retry()
     if discovered is None:
-        print("ERROR: No SCUF controller found!")
-        print("  - Is the controller plugged in via USB?")
+        print("ERROR: No SCUF controller found after 30s!")
+        print("  - Is the controller plugged in via USB or wireless receiver connected?")
         print("  - Check: lsusb | grep 1b1c")
         sys.exit(1)
 


### PR DESCRIPTION
The kernel needs time to enumerate USB interfaces and create evdev nodes after a controller is plugged in or powered on wirelessly. Previously the driver called discover_scuf() once and immediately failed, requiring the user to manually retry.

New discover_scuf_with_retry() polls up to 15 times (2s apart, 30s max) with clear per-attempt logging so users see exactly what's happening during enumeration:

  Searching for wired controller (1b1c:3a05)... not found
  Searching for wireless receiver (1b1c:3a08)... not found
  Controller not found, waiting for device enumeration... (attempt 1/15)

Applied to both the driver (bridge.py) and diagnostic tool (diag.py).

https://claude.ai/code/session_01FVu1QqRTjZ8sDF8WYbJEdy