### PR TITLE
Fix WirePlumber rule: match on api.alsa.card.name, not vendor/product ID

### DIFF
--- a/50-scuf-audio.conf
+++ b/50-scuf-audio.conf
@@ -8,6 +8,10 @@
 # broken hardware dB scale. The udev rules set the hardware mixer to
 # max on connect so software attenuation has the full signal range.
 #
+# Match on api.alsa.card.name (the property actually present on the
+# ALSA sink node), NOT device.vendor.id/device.product.id (which don't
+# exist on these nodes).
+#
 # Install: sudo cp 50-scuf-audio.conf /etc/wireplumber/wireplumber.conf.d/
 # Then restart WirePlumber or reboot.
 
@@ -15,8 +19,7 @@ monitor.alsa.rules = [
   {
     matches = [
       {
-        device.vendor.id = "6940"
-        device.product.id = "14853"
+        api.alsa.card.name = "SCUF Envision Pro Controller V2"
       }
     ]
     actions = {
@@ -29,8 +32,7 @@ monitor.alsa.rules = [
   {
     matches = [
       {
-        device.vendor.id = "6940"
-        device.product.id = "14856"
+        api.alsa.card.name = "SCUF Envision Pro Wireless USB"
       }
     ]
     actions = {


### PR DESCRIPTION
The ALSA sink nodes don't expose device.vendor.id or device.product.id, so the previous rule matched nothing and api.alsa.soft-mixer was never applied. Match on api.alsa.card.name instead, which is the property actually present on the node (confirmed via wpctl inspect).

https://claude.ai/code/session_01FVu1QqRTjZ8sDF8WYbJEdy