### PR TITLE
Add +12 dB gain boost filter for quiet SCUF headphone output

### DIFF
--- a/50-scuf-gain.conf
+++ b/50-scuf-gain.conf
@@ -1,0 +1,70 @@
+# SCUF Envision Pro V2 — Gain boost for quiet headphone output
+#
+# The SCUF's hardware mixer maxes out at -16 dB, making audio much
+# quieter than expected even at 100% software volume. This filter chain
+# applies a flat +12 dB gain boost via PipeWire DSP to compensate.
+#
+# The smart filter automatically inserts this gain stage whenever audio
+# is routed to the SCUF headphone output. Other audio devices are
+# unaffected.
+#
+# Adjust the "gain" value below if audio is too loud or too quiet:
+#   +6 dB  = ~2x louder    (conservative)
+#   +12 dB = ~4x louder    (recommended default)
+#   +16 dB = ~6x louder    (fully compensates hardware -16 dB deficit)
+#   +18 dB = ~8x louder    (risk of clipping on loud content)
+#
+# Install: sudo cp 50-scuf-gain.conf /etc/pipewire/pipewire.conf.d/
+# Then restart PipeWire or reboot.
+
+context.modules = [
+  {
+    name = libpipewire-module-filter-chain
+    args = {
+      node.description = "SCUF Gain Boost"
+      media.name = "SCUF Gain Boost"
+      filter.graph = {
+        nodes = [
+          {
+            type = builtin
+            name = eq_left
+            label = param_eq
+            config = {
+              filters = [
+                { type = bq_highshelf, freq = 0, gain = 12.0, q = 1.0 }
+              ]
+            }
+          }
+          {
+            type = builtin
+            name = eq_right
+            label = param_eq
+            config = {
+              filters = [
+                { type = bq_highshelf, freq = 0, gain = 12.0, q = 1.0 }
+              ]
+            }
+          }
+        ]
+        links = []
+        inputs = [ "eq_left:In" "eq_right:In" ]
+        outputs = [ "eq_left:Out" "eq_right:Out" ]
+      }
+      audio.channels = 2
+      audio.position = [ FL FR ]
+      capture.props = {
+        node.name = "effect_input.scuf_gain"
+        media.class = Audio/Sink
+        filter.smart = true
+        filter.smart.name = "scuf-gain-boost"
+        filter.smart.target = {
+          api.alsa.card.name = "~SCUF Envision*"
+        }
+      }
+      playback.props = {
+        node.name = "effect_output.scuf_gain"
+        node.passive = true
+      }
+    }
+  }
+]

--- a/README.md
+++ b/README.md
@@ -92,22 +92,27 @@ sudo udevadm trigger
 
 ### Step 5: Enable Headphone Audio (Recommended)
 
-The SCUF controller has a built-in headphone jack, but its USB audio "Headset" mixer reports an invalid dB range. PipeWire/WirePlumber disables dB-based volume mapping, making the volume slider cosmetic-only (only mute actually works).
+The SCUF controller has a built-in headphone jack, but its USB audio has two issues:
+1. The "Headset" mixer reports an invalid dB range, making the volume slider cosmetic-only
+2. The hardware mixer maxes out at -16 dB, making audio much quieter than expected
 
-This one-time fix installs a WirePlumber config that forces software volume mixing:
+This one-time fix installs a WirePlumber config (software volume) and a PipeWire filter-chain (+12 dB gain boost):
 
 ```bash
 sudo bash tools/setup_scuf_audio.sh
 ```
 
-Then **reboot** (or run `systemctl --user restart wireplumber` as your normal user). After that, the headphone volume slider will work normally. The udev rules also auto-set the hardware mixer to max on each connect.
+Then **reboot** (or run `systemctl --user restart pipewire wireplumber` as your normal user). After that, the headphone volume slider will work normally at comparable loudness to other devices. The udev rules also auto-set the hardware mixer to max on each connect.
+
+To adjust gain if audio is too loud/quiet, edit `/etc/pipewire/pipewire.conf.d/50-scuf-gain.conf` and change the `gain = 12.0` value (+6 = 2x, +12 = 4x, +16 = 6x louder).
 
 To undo:
 
 ```bash
 sudo rm /etc/wireplumber/wireplumber.conf.d/50-scuf-audio.conf
+sudo rm /etc/pipewire/pipewire.conf.d/50-scuf-gain.conf
 sudo udevadm control --reload-rules
-# Then reboot or restart WirePlumber
+# Then reboot or restart PipeWire/WirePlumber
 ```
 
 ---
@@ -278,6 +283,7 @@ sudo rm -f /etc/udev/rules.d/99-scuf-envision.rules
 
 # Remove the audio config (if you ran setup_scuf_audio.sh)
 sudo rm -f /etc/wireplumber/wireplumber.conf.d/50-scuf-audio.conf
+sudo rm -f /etc/pipewire/pipewire.conf.d/50-scuf-gain.conf
 
 # Reload udev so the rules take effect immediately
 sudo udevadm control --reload-rules
@@ -346,6 +352,7 @@ sudo rm -rf /opt/scuf-envision
 # Remove all udev rules
 sudo rm -f /etc/udev/rules.d/99-scuf-envision.rules
 sudo rm -f /etc/wireplumber/wireplumber.conf.d/50-scuf-audio.conf
+sudo rm -f /etc/pipewire/pipewire.conf.d/50-scuf-gain.conf
 sudo udevadm control --reload-rules
 sudo udevadm trigger
 
@@ -498,6 +505,7 @@ scuf-envision-pro-V2-Linux/
     diag.py                   # Raw event diagnostic tool
     setup_scuf_audio.sh       # Headphone audio setup (WirePlumber software volume)
   50-scuf-audio.conf           # WirePlumber config for headphone audio
+  50-scuf-gain.conf            # PipeWire filter-chain for gain boost
   99-scuf-envision.rules      # udev rules for device permissions
   scuf-envision.service       # systemd service file
   install.sh                  # Automated installer

--- a/install.sh
+++ b/install.sh
@@ -62,15 +62,19 @@ echo "  Service installed (not started yet)"
 # Step 6: Install audio config
 echo "[6/6] Installing audio config (headphone volume fix)..."
 WP_CONF_DIR="/etc/wireplumber/wireplumber.conf.d"
+PW_CONF_DIR="/etc/pipewire/pipewire.conf.d"
 OLD_DISABLE_RULE="/etc/udev/rules.d/98-scuf-no-audio.rules"
 mkdir -p "$WP_CONF_DIR"
 cp "$SCRIPT_DIR/50-scuf-audio.conf" "$WP_CONF_DIR/"
 echo "  Installed WirePlumber config to $WP_CONF_DIR/50-scuf-audio.conf"
+mkdir -p "$PW_CONF_DIR"
+cp "$SCRIPT_DIR/50-scuf-gain.conf" "$PW_CONF_DIR/"
+echo "  Installed PipeWire gain boost to $PW_CONF_DIR/50-scuf-gain.conf"
 if [ -f "$OLD_DISABLE_RULE" ]; then
     rm -f "$OLD_DISABLE_RULE"
     echo "  Removed old audio-disable workaround: $OLD_DISABLE_RULE"
 fi
-echo "  Note: Restart WirePlumber or reboot for audio changes to take effect"
+echo "  Note: Restart PipeWire/WirePlumber or reboot for audio changes to take effect"
 
 echo ""
 echo "======================================"

--- a/tools/setup_scuf_audio.sh
+++ b/tools/setup_scuf_audio.sh
@@ -2,14 +2,16 @@
 # SCUF Envision Pro V2 — Enable headphone audio with working volume control
 #
 # The SCUF's USB audio "Headset" mixer has a broken dB range that makes
-# hardware volume non-functional under PipeWire/WirePlumber. This script:
+# hardware volume non-functional under PipeWire/WirePlumber. Additionally,
+# the hardware mixer maxes out at -16 dB, making audio very quiet. This script:
 #   1. Installs a WirePlumber config to use software volume mixing
-#   2. Sets the hardware mixer to maximum (software handles attenuation)
-#   3. Removes the old audio-disable workaround if present
+#   2. Installs a PipeWire filter-chain for +12 dB gain boost
+#   3. Sets the hardware mixer to maximum (software handles attenuation)
+#   4. Removes the old audio-disable workaround if present
 #
 # Run: sudo bash tools/setup_scuf_audio.sh
 #
-# After running, restart WirePlumber or reboot for changes to take effect.
+# After running, reboot or restart PipeWire/WirePlumber for changes to take effect.
 
 set -e
 
@@ -17,6 +19,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
 WP_CONF_DIR="/etc/wireplumber/wireplumber.conf.d"
 WP_CONF_FILE="$WP_CONF_DIR/50-scuf-audio.conf"
+PW_CONF_DIR="/etc/pipewire/pipewire.conf.d"
+PW_GAIN_FILE="$PW_CONF_DIR/50-scuf-gain.conf"
 OLD_DISABLE_RULE="/etc/udev/rules.d/98-scuf-no-audio.rules"
 
 if [ "$EUID" -ne 0 ]; then
@@ -31,28 +35,35 @@ echo ""
 
 # Step 1: Remove old audio-disable workaround
 if [ -f "$OLD_DISABLE_RULE" ]; then
-    echo "[1/4] Removing old audio-disable workaround..."
+    echo "[1/5] Removing old audio-disable workaround..."
     rm -f "$OLD_DISABLE_RULE"
     echo "  Removed: $OLD_DISABLE_RULE"
     echo "  (The SCUF audio driver will now be allowed to load)"
 else
-    echo "[1/4] No old audio-disable workaround found (OK)"
+    echo "[1/5] No old audio-disable workaround found (OK)"
 fi
 
 # Step 2: Install WirePlumber config for software volume
-echo "[2/4] Installing WirePlumber config..."
+echo "[2/5] Installing WirePlumber config..."
 mkdir -p "$WP_CONF_DIR"
 cp "$REPO_DIR/50-scuf-audio.conf" "$WP_CONF_FILE"
 echo "  Installed: $WP_CONF_FILE"
 echo "  (Forces software volume mixing for SCUF audio)"
 
-# Step 3: Reload udev rules (for the mixer-max rule in 99-scuf-envision.rules)
-echo "[3/4] Reloading udev rules..."
+# Step 3: Install PipeWire filter-chain for gain boost
+echo "[3/5] Installing PipeWire gain boost filter..."
+mkdir -p "$PW_CONF_DIR"
+cp "$REPO_DIR/50-scuf-gain.conf" "$PW_GAIN_FILE"
+echo "  Installed: $PW_GAIN_FILE"
+echo "  (Applies +12 dB gain boost to compensate for hardware -16 dB ceiling)"
+
+# Step 4: Reload udev rules (for the mixer-max rule in 99-scuf-envision.rules)
+echo "[4/5] Reloading udev rules..."
 udevadm control --reload-rules
 echo "  Done"
 
-# Step 4: Set SCUF mixer to max right now (if controller is connected)
-echo "[4/4] Setting SCUF hardware mixer to maximum..."
+# Step 5: Set SCUF mixer to max right now (if controller is connected)
+echo "[5/5] Setting SCUF hardware mixer to maximum..."
 FOUND_CARD=false
 for card_dir in /sys/class/sound/card*/; do
     card_num=$(basename "$card_dir" | sed 's/card//')
@@ -94,13 +105,18 @@ echo "======================================"
 echo ""
 echo "To apply changes, either:"
 echo "  1. Reboot (recommended), or"
-echo "  2. Restart WirePlumber:"
-echo "     systemctl --user restart wireplumber"
+echo "  2. Restart PipeWire + WirePlumber:"
+echo "     systemctl --user restart pipewire wireplumber"
 echo "     (run as your normal user, NOT as root)"
 echo ""
-echo "After restart, the SCUF headphone volume slider should work normally."
+echo "After restart, the SCUF headphone volume slider should work normally"
+echo "with a +12 dB gain boost to compensate for the quiet hardware output."
+echo ""
+echo "To adjust the gain: edit $PW_GAIN_FILE"
+echo "  Change 'gain = 12.0' to a different value (6, 16, 18, etc.)"
+echo "  Then restart PipeWire or reboot."
 echo ""
 echo "To undo this setup:"
-echo "  sudo rm $WP_CONF_FILE"
+echo "  sudo rm $WP_CONF_FILE $PW_GAIN_FILE"
 echo "  sudo udevadm control --reload-rules"
-echo "  (then reboot or restart WirePlumber)"
+echo "  (then reboot or restart PipeWire/WirePlumber)"


### PR DESCRIPTION
The SCUF's hardware mixer maxes out at -16 dB, making audio much quieter than Windows even at 150% software volume. Add a PipeWire filter-chain (50-scuf-gain.conf) that applies +12 dB flat gain via bq_highshelf at freq 0, auto-targeted to SCUF devices via WirePlumber smart filters.

The gain value is user-adjustable in the config file.

https://claude.ai/code/session_01FVu1QqRTjZ8sDF8WYbJEdy