### PR TITLE
Fix gain filter: target by node.name and move smart filter props to a…

### DIFF
--- a/50-scuf-gain.conf
+++ b/50-scuf-gain.conf
@@ -16,6 +16,11 @@
 #
 # Install: sudo cp 50-scuf-gain.conf /etc/pipewire/pipewire.conf.d/
 # Then restart PipeWire or reboot.
+#
+# Troubleshooting: If the filter loads but doesn't attach, check:
+#   1. pw-dump | grep -A5 scuf_gain  (verify filter nodes exist)
+#   2. wpctl status                   (look for "SCUF Gain Boost" under Filters)
+#   3. The smart-filter WirePlumber policy must be enabled (default on most distros)
 
 context.modules = [
   {
@@ -23,6 +28,15 @@ context.modules = [
     args = {
       node.description = "SCUF Gain Boost"
       media.name = "SCUF Gain Boost"
+      # Smart filter properties at args level so they become global node
+      # properties visible to WirePlumber's smart-filter policy.
+      # Target matches by node.name (present on ALSA sink nodes) rather
+      # than api.alsa.card.name (which only exists on device objects).
+      filter.smart = true
+      filter.smart.name = "scuf-gain-boost"
+      filter.smart.target = {
+        node.name = "~alsa_output.usb-Scuf_Gaming_SCUF_Envision_Pro*"
+      }
       filter.graph = {
         nodes = [
           {
@@ -55,11 +69,6 @@ context.modules = [
       capture.props = {
         node.name = "effect_input.scuf_gain"
         media.class = Audio/Sink
-        filter.smart = true
-        filter.smart.name = "scuf-gain-boost"
-        filter.smart.target = {
-          api.alsa.card.name = "~SCUF Envision*"
-        }
       }
       playback.props = {
         node.name = "effect_output.scuf_gain"


### PR DESCRIPTION
…rgs level

The gain boost filter was not attaching to the SCUF sink because:

1. filter.smart.target matched on api.alsa.card.name, which is a property on ALSA device/card objects, not on sink nodes. Changed to match on node.name with a glob pattern that covers both wired and wireless SCUF variants.

2. filter.smart.* properties were inside capture.props (stream node) where WirePlumber's smart-filter policy may not see them. Moved to the args level so they become global node properties visible to the policy engine.

https://claude.ai/code/session_018fRYLTCdVFk9puhrxfY9D9