### PR TITLE
Fix smart filter: move filter.smart.* back to capture.props (main node)

### DIFF
--- a/50-scuf-gain.conf
+++ b/50-scuf-gain.conf
@@ -28,15 +28,6 @@ context.modules = [
     args = {
       node.description = "SCUF Gain Boost"
       media.name = "SCUF Gain Boost"
-      # Smart filter properties at args level so they become global node
-      # properties visible to WirePlumber's smart-filter policy.
-      # Target matches by node.name (present on ALSA sink nodes) rather
-      # than api.alsa.card.name (which only exists on device objects).
-      filter.smart = true
-      filter.smart.name = "scuf-gain-boost"
-      filter.smart.target = {
-        node.name = "~alsa_output.usb-Scuf_Gaming_SCUF_Envision_Pro*"
-      }
       filter.graph = {
         nodes = [
           {
@@ -69,6 +60,17 @@ context.modules = [
       capture.props = {
         node.name = "effect_input.scuf_gain"
         media.class = Audio/Sink
+        # Smart filter properties must be on the main node (capture side
+        # for Audio/Sink filters), not at args level or on playback.props.
+        # WirePlumber reads these to auto-insert the filter between streams
+        # and the target SCUF sink.
+        filter.smart = true
+        filter.smart.name = "scuf-gain-boost"
+        # Target by node.name (present on ALSA sink nodes).
+        # ~ prefix = glob/fnmatch match; covers both wired and wireless.
+        filter.smart.target = {
+          node.name = "~alsa_output.usb-Scuf_Gaming_SCUF_Envision_Pro*"
+        }
       }
       playback.props = {
         node.name = "effect_output.scuf_gain"


### PR DESCRIPTION
The previous commit moved filter.smart properties to the top-level args block, but WirePlumber's smart filter policy requires these on the filter's main node. For Audio/Sink filters, the main node is the capture side (capture.props). At args level, the simple boolean filter.smart=true propagated (filter appeared under Filters in wpctl), but the nested filter.smart.target object did not serialize correctly into node properties, so WirePlumber could never match the target — streams bypassed the filter and connected directly to the SCUF sink.

Fix: move filter.smart, filter.smart.name, and filter.smart.target back into capture.props while keeping the corrected node.name target key (not the original api.alsa.card.name which only exists on device objects).

https://claude.ai/code/session_018fRYLTCdVFk9puhrxfY9D9