### PR TITLE
Fix gain filter: use WirePlumber component instead of PipeWire contex…

### DIFF
--- a/50-scuf-gain.conf
+++ b/50-scuf-gain.conf
@@ -1,81 +1,62 @@
 # SCUF Envision Pro V2 — Gain boost for quiet headphone output
 #
 # The SCUF's hardware mixer maxes out at -16 dB, making audio much
-# quieter than expected even at 100% software volume. This filter chain
-# applies a flat +12 dB gain boost via PipeWire DSP to compensate.
+# quieter than expected even at 100% software volume. This WirePlumber
+# component applies a flat +12 dB gain boost via a smart filter that
+# transparently inserts between audio streams and the SCUF sink.
 #
-# The smart filter automatically inserts this gain stage whenever audio
-# is routed to the SCUF headphone output. Other audio devices are
-# unaffected.
+# This MUST be loaded as a WirePlumber component (not a PipeWire
+# context.modules entry) so that WirePlumber's smart filter policy
+# manages the lifecycle and auto-linking.
 #
-# Adjust the "gain" value below if audio is too loud or too quiet:
+# Adjust the "Gain" value below if audio is too loud or too quiet:
 #   +6 dB  = ~2x louder    (conservative)
 #   +12 dB = ~4x louder    (recommended default)
 #   +16 dB = ~6x louder    (fully compensates hardware -16 dB deficit)
 #   +18 dB = ~8x louder    (risk of clipping on loud content)
 #
-# Install: sudo cp 50-scuf-gain.conf /etc/pipewire/pipewire.conf.d/
-# Then restart PipeWire or reboot.
-#
-# Troubleshooting: If the filter loads but doesn't attach, check:
-#   1. pw-dump | grep -A5 scuf_gain  (verify filter nodes exist)
-#   2. wpctl status                   (look for "SCUF Gain Boost" under Filters)
-#   3. The smart-filter WirePlumber policy must be enabled (default on most distros)
+# Install: sudo cp 50-scuf-gain.conf /etc/wireplumber/wireplumber.conf.d/
+#          (same directory as 50-scuf-audio.conf)
+# Then restart PipeWire/WirePlumber or reboot.
 
-context.modules = [
+wireplumber.profiles = {
+  main = {
+    filter.sink.scuf-gain = required
+  }
+}
+
+wireplumber.components = [
   {
-    name = libpipewire-module-filter-chain
-    args = {
+    name = libpipewire-module-filter-chain, type = pw-module
+    arguments = {
+      node.name        = "filter.sink.scuf-gain"
       node.description = "SCUF Gain Boost"
-      media.name = "SCUF Gain Boost"
+      media.name       = "SCUF Gain Boost"
       filter.graph = {
         nodes = [
           {
-            type = builtin
-            name = eq_left
-            label = param_eq
-            config = {
-              filters = [
-                { type = bq_highshelf, freq = 0, gain = 12.0, q = 1.0 }
-              ]
-            }
-          }
-          {
-            type = builtin
-            name = eq_right
-            label = param_eq
-            config = {
-              filters = [
-                { type = bq_highshelf, freq = 0, gain = 12.0, q = 1.0 }
-              ]
-            }
+            type    = builtin
+            name    = gain
+            label   = bq_highshelf
+            control = { "Freq" = 0.0, "Q" = 1.0, "Gain" = 12.0 }
           }
         ]
-        links = []
-        inputs = [ "eq_left:In" "eq_right:In" ]
-        outputs = [ "eq_left:Out" "eq_right:Out" ]
       }
       audio.channels = 2
-      audio.position = [ FL FR ]
+      audio.position = [ FL, FR ]
       capture.props = {
-        node.name = "effect_input.scuf_gain"
-        media.class = Audio/Sink
-        # Smart filter properties must be on the main node (capture side
-        # for Audio/Sink filters), not at args level or on playback.props.
-        # WirePlumber reads these to auto-insert the filter between streams
-        # and the target SCUF sink.
-        filter.smart = true
-        filter.smart.name = "scuf-gain-boost"
-        # Target by node.name (present on ALSA sink nodes).
-        # ~ prefix = glob/fnmatch match; covers both wired and wireless.
+        media.class         = Audio/Sink
+        filter.smart        = true
+        filter.smart.name   = "filter.sink.scuf-gain"
         filter.smart.target = {
           node.name = "~alsa_output.usb-Scuf_Gaming_SCUF_Envision_Pro*"
         }
       }
       playback.props = {
-        node.name = "effect_output.scuf_gain"
         node.passive = true
+        media.role   = "DSP"
       }
     }
+    provides = filter.sink.scuf-gain
   }
 ]


### PR DESCRIPTION
…t.modules

Previous attempts loaded the smart filter via PipeWire's context.modules (in /etc/pipewire/pipewire.conf.d/). This is fundamentally wrong — WirePlumber's smart filter policy only manages components loaded through wireplumber.components. The filter would appear as an orphaned Audio/Sink that never auto-linked.

Rewrite 50-scuf-gain.conf to use WirePlumber's wireplumber.components + wireplumber.profiles mechanism, matching the official smart-equalizer.conf example. The gain filter now installs to /etc/wireplumber/wireplumber.conf.d/ alongside 50-scuf-audio.conf.

Also simplify the filter graph from dual param_eq nodes to a single bq_highshelf (PipeWire auto-duplicates for stereo channels).

https://claude.ai/code/session_018fRYLTCdVFk9puhrxfY9D9