### PR TITLE
Switch gain filter to WirePlumber Software DSP (node.software-dsp.rules)

### DIFF
--- a/50-scuf-gain.conf
+++ b/50-scuf-gain.conf
@@ -1,13 +1,14 @@
 # SCUF Envision Pro V2 — Gain boost for quiet headphone output
 #
 # The SCUF's hardware mixer maxes out at -16 dB, making audio much
-# quieter than expected even at 100% software volume. This WirePlumber
-# component applies a flat +12 dB gain boost via a smart filter that
-# transparently inserts between audio streams and the SCUF sink.
+# quieter than expected even at 100% software volume.
 #
-# This MUST be loaded as a WirePlumber component (not a PipeWire
-# context.modules entry) so that WirePlumber's smart filter policy
-# manages the lifecycle and auto-linking.
+# This config uses WirePlumber's Software DSP mechanism to transparently
+# apply a +12 dB gain boost on the SCUF output sink. When the SCUF is
+# connected, WirePlumber creates a virtual sink with gain processing
+# that routes audio to the real hardware sink.
+#
+# Only targets audio OUTPUT (alsa_output.*), not the microphone input.
 #
 # Adjust the "Gain" value below if audio is too loud or too quiet:
 #   +6 dB  = ~2x louder    (conservative)
@@ -18,45 +19,51 @@
 # Install: sudo cp 50-scuf-gain.conf /etc/wireplumber/wireplumber.conf.d/
 #          (same directory as 50-scuf-audio.conf)
 # Then restart PipeWire/WirePlumber or reboot.
+#
+# Requires WirePlumber 0.5.7+ (node.software-dsp feature).
+# The 'optional' profile entry ensures WirePlumber still starts if the
+# feature is unavailable on older versions.
 
 wireplumber.profiles = {
   main = {
-    filter.sink.scuf-gain = required
+    node.software-dsp = optional
   }
 }
 
-wireplumber.components = [
+node.software-dsp.rules = [
   {
-    name = libpipewire-module-filter-chain, type = pw-module
-    arguments = {
-      node.name        = "filter.sink.scuf-gain"
-      node.description = "SCUF Gain Boost"
-      media.name       = "SCUF Gain Boost"
-      filter.graph = {
-        nodes = [
-          {
-            type    = builtin
-            name    = gain
-            label   = bq_highshelf
-            control = { "Freq" = 0.0, "Q" = 1.0, "Gain" = 12.0 }
+    matches = [
+      {
+        node.name = "~alsa_output.usb-Scuf_Gaming_SCUF_Envision_Pro*"
+      }
+    ]
+    actions = {
+      create-filter = {
+        filter-graph = {
+          node.description = "SCUF Gain Boost"
+          media.name       = "SCUF Gain Boost"
+          filter.graph = {
+            nodes = [
+              {
+                type    = builtin
+                name    = gain
+                label   = bq_highshelf
+                control = { "Freq" = 0.0, "Q" = 1.0, "Gain" = 12.0 }
+              }
+            ]
           }
-        ]
-      }
-      audio.channels = 2
-      audio.position = [ FL, FR ]
-      capture.props = {
-        media.class         = Audio/Sink
-        filter.smart        = true
-        filter.smart.name   = "filter.sink.scuf-gain"
-        filter.smart.target = {
-          node.name = "~alsa_output.usb-Scuf_Gaming_SCUF_Envision_Pro*"
+          audio.channels = 2
+          audio.position = [ FL, FR ]
+          capture.props = {
+            media.class = Audio/Sink
+          }
+          playback.props = {
+            node.passive = true
+            media.role   = "DSP"
+          }
         }
-      }
-      playback.props = {
-        node.passive = true
-        media.role   = "DSP"
+        hide-parent = false
       }
     }
-    provides = filter.sink.scuf-gain
   }
 ]

--- a/tools/setup_scuf_audio.sh
+++ b/tools/setup_scuf_audio.sh
@@ -54,11 +54,11 @@ cp "$REPO_DIR/50-scuf-audio.conf" "$WP_CONF_FILE"
 echo "  Installed: $WP_CONF_FILE"
 echo "  (Forces software volume mixing for SCUF audio)"
 
-# Step 3: Install WirePlumber gain boost component
+# Step 3: Install WirePlumber gain boost (Software DSP)
 echo "[3/5] Installing WirePlumber gain boost filter..."
 cp "$REPO_DIR/50-scuf-gain.conf" "$WP_GAIN_FILE"
 echo "  Installed: $WP_GAIN_FILE"
-echo "  (Smart filter: +12 dB gain, auto-links to SCUF sink only)"
+echo "  (Software DSP: +12 dB gain on SCUF output only, mic unaffected)"
 
 # Step 4: Reload udev rules (for the mixer-max rule in 99-scuf-envision.rules)
 echo "[4/5] Reloading udev rules..."


### PR DESCRIPTION
Smart filters (filter.smart) failed to auto-link across 3 different loading mechanisms (PipeWire context.modules, WirePlumber components). The filter always loaded but never inserted between streams and the SCUF sink.

Switch to WirePlumber's Software DSP mechanism which is designed for exactly this use case — devices that need transparent userspace DSP. Instead of creating a standalone filter and relying on smart-filter policy to link it, Software DSP rules match the device node directly and WirePlumber manages the DSP lifecycle.

The 'optional' profile entry ensures WirePlumber still starts normally if the node.software-dsp feature isn't available (older WP versions).

Only targets alsa_output.* (headphone sink), not alsa_input.* (mic).

https://claude.ai/code/session_018fRYLTCdVFk9puhrxfY9D9