### PR TITLE
Fix SCUF audio config: install gain boost to WirePlumber dir, not Pip…

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ sudo bash tools/setup_scuf_audio.sh
 
 Then **reboot** (or run `systemctl --user restart pipewire wireplumber` as your normal user). After that, the headphone volume slider will work normally at comparable loudness to other devices. The udev rules also auto-set the hardware mixer to max on each connect.
 
-To adjust gain if audio is too loud/quiet, edit `/etc/pipewire/pipewire.conf.d/50-scuf-gain.conf` and change the `gain = 12.0` value (+6 = 2x, +12 = 4x, +16 = 6x louder).
+To adjust gain if audio is too loud/quiet, edit `/etc/wireplumber/wireplumber.conf.d/50-scuf-gain.conf` and change the `"Gain" = 12.0` value (+6 = 2x, +12 = 4x, +16 = 6x louder).
 
 To undo:
 
 ```bash
 sudo rm /etc/wireplumber/wireplumber.conf.d/50-scuf-audio.conf
-sudo rm /etc/pipewire/pipewire.conf.d/50-scuf-gain.conf
+sudo rm /etc/wireplumber/wireplumber.conf.d/50-scuf-gain.conf
 sudo udevadm control --reload-rules
 # Then reboot or restart PipeWire/WirePlumber
 ```
@@ -283,7 +283,7 @@ sudo rm -f /etc/udev/rules.d/99-scuf-envision.rules
 
 # Remove the audio config (if you ran setup_scuf_audio.sh)
 sudo rm -f /etc/wireplumber/wireplumber.conf.d/50-scuf-audio.conf
-sudo rm -f /etc/pipewire/pipewire.conf.d/50-scuf-gain.conf
+sudo rm -f /etc/wireplumber/wireplumber.conf.d/50-scuf-gain.conf
 
 # Reload udev so the rules take effect immediately
 sudo udevadm control --reload-rules
@@ -352,7 +352,7 @@ sudo rm -rf /opt/scuf-envision
 # Remove all udev rules
 sudo rm -f /etc/udev/rules.d/99-scuf-envision.rules
 sudo rm -f /etc/wireplumber/wireplumber.conf.d/50-scuf-audio.conf
-sudo rm -f /etc/pipewire/pipewire.conf.d/50-scuf-gain.conf
+sudo rm -f /etc/wireplumber/wireplumber.conf.d/50-scuf-gain.conf
 sudo udevadm control --reload-rules
 sudo udevadm trigger
 
@@ -505,7 +505,7 @@ scuf-envision-pro-V2-Linux/
     diag.py                   # Raw event diagnostic tool
     setup_scuf_audio.sh       # Headphone audio setup (WirePlumber software volume)
   50-scuf-audio.conf           # WirePlumber config for headphone audio
-  50-scuf-gain.conf            # PipeWire filter-chain for gain boost
+  50-scuf-gain.conf            # WirePlumber software-DSP gain boost
   99-scuf-envision.rules      # udev rules for device permissions
   scuf-envision.service       # systemd service file
   install.sh                  # Automated installer

--- a/install.sh
+++ b/install.sh
@@ -62,14 +62,17 @@ echo "  Service installed (not started yet)"
 # Step 6: Install audio config
 echo "[6/6] Installing audio config (headphone volume fix)..."
 WP_CONF_DIR="/etc/wireplumber/wireplumber.conf.d"
-PW_CONF_DIR="/etc/pipewire/pipewire.conf.d"
+OLD_PW_GAIN_FILE="/etc/pipewire/pipewire.conf.d/50-scuf-gain.conf"
 OLD_DISABLE_RULE="/etc/udev/rules.d/98-scuf-no-audio.rules"
 mkdir -p "$WP_CONF_DIR"
 cp "$SCRIPT_DIR/50-scuf-audio.conf" "$WP_CONF_DIR/"
 echo "  Installed WirePlumber config to $WP_CONF_DIR/50-scuf-audio.conf"
-mkdir -p "$PW_CONF_DIR"
-cp "$SCRIPT_DIR/50-scuf-gain.conf" "$PW_CONF_DIR/"
-echo "  Installed PipeWire gain boost to $PW_CONF_DIR/50-scuf-gain.conf"
+cp "$SCRIPT_DIR/50-scuf-gain.conf" "$WP_CONF_DIR/"
+echo "  Installed WirePlumber gain boost to $WP_CONF_DIR/50-scuf-gain.conf"
+if [ -f "$OLD_PW_GAIN_FILE" ]; then
+    rm -f "$OLD_PW_GAIN_FILE"
+    echo "  Removed stale PipeWire gain config: $OLD_PW_GAIN_FILE"
+fi
 if [ -f "$OLD_DISABLE_RULE" ]; then
     rm -f "$OLD_DISABLE_RULE"
     echo "  Removed old audio-disable workaround: $OLD_DISABLE_RULE"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -19,13 +19,20 @@ systemctl disable scuf-envision.service 2>/dev/null || true
 rm -f /etc/systemd/system/scuf-envision.service
 systemctl daemon-reload
 
-echo "[2/3] Removing udev rules..."
+echo "[2/4] Removing udev rules..."
 rm -f /etc/udev/rules.d/99-scuf-envision.rules
 udevadm control --reload-rules
 
-echo "[3/3] Removing installed files..."
+echo "[3/4] Removing audio configs..."
+rm -f /etc/wireplumber/wireplumber.conf.d/50-scuf-audio.conf
+rm -f /etc/wireplumber/wireplumber.conf.d/50-scuf-gain.conf
+rm -f /etc/pipewire/pipewire.conf.d/50-scuf-gain.conf
+echo "  Removed WirePlumber and PipeWire audio configs (if present)"
+
+echo "[4/4] Removing installed files..."
 rm -rf /opt/scuf-envision
 
 echo ""
 echo "Uninstall complete."
 echo "Note: python-evdev and uinput module were not removed."
+echo "Restart PipeWire/WirePlumber or reboot to apply audio changes."


### PR DESCRIPTION
…eWire

install.sh was copying 50-scuf-gain.conf to /etc/pipewire/pipewire.conf.d/ but the file contains WirePlumber-specific sections (wireplumber.profiles, node.software-dsp.rules) that PipeWire silently ignores. This caused the +12 dB gain boost to never activate.

- install.sh: copy gain config to /etc/wireplumber/wireplumber.conf.d/, clean up stale PipeWire copy if present
- uninstall.sh: add missing removal of audio config files
- README.md: fix all gain config path references

https://claude.ai/code/session_018fRYLTCdVFk9puhrxfY9D9