### PR TITLE
Remove device path restrictions from scuf-envision systemd service

### DIFF
--- a/scuf-envision.service
+++ b/scuf-envision.service
@@ -16,8 +16,6 @@ User=root
 # Hardening
 ProtectHome=true
 ProtectSystem=strict
-ReadWritePaths=/dev/input /dev/uinput /dev/snd /dev/hidraw0 /dev/hidraw1 /dev/hidraw2 /dev/hidraw3 /dev/hidraw4 /dev/hidraw5 /dev/hidraw6 /dev/hidraw7 /dev/hidraw8 /dev/hidraw9 /dev/hidraw10 /dev/hidraw11 /dev/hidraw12 /dev/hidraw13 /dev/hidraw14 /dev/hidraw15 /dev/hidraw16 /dev/hidraw17 /dev/hidraw18 /dev/hidraw19 /dev/hidraw20
-ReadOnlyPaths=/sys/class/input /sys/class/hidraw
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
Removed the `ReadWritePaths` and `ReadOnlyPaths` security directives from the scuf-envision systemd service unit file.

## Changes
- Removed `ReadWritePaths` directive that explicitly allowed access to `/dev/input`, `/dev/uinput`, `/dev/snd`, and `/dev/hidraw*` devices
- Removed `ReadOnlyPaths` directive that restricted read-only access to `/sys/class/input` and `/sys/class/hidraw`

## Notes
This change relaxes the security hardening constraints previously applied to the service. The service will now operate under the default filesystem access policies defined by `ProtectHome=true` and `ProtectSystem=strict` without explicit device path allowlisting.

https://claude.ai/code/session_015S4cxo7GiKoffEmJbZL6Yv