### PR TITLE
Add USB audio disable/enable control for SCUF Envision Pro V2

### DIFF
--- a/config.ini.default
+++ b/config.ini.default
@@ -1,0 +1,8 @@
+[audio]
+# Set to true to completely disable USB audio (headphone jack) on the
+# SCUF controller. The audio device is unbound from the kernel driver
+# so applications (PipeWire, PulseAudio, etc.) will not see it at all.
+#
+# To toggle at runtime:  sudo scuf-audio-toggle disable|enable
+# To apply after editing: sudo systemctl restart scuf-envision
+disabled = false

--- a/scuf_envision/audio_control.py
+++ b/scuf_envision/audio_control.py
@@ -1,0 +1,170 @@
+"""
+USB audio disable/enable for SCUF Envision Pro V2.
+
+Controls the snd-usb-audio kernel driver binding for SCUF audio interfaces.
+Unbinding removes the audio device entirely from the system (PipeWire won't
+see it). Rebinding restores it.
+
+Requires root (writes to /sys/bus/usb/drivers/snd-usb-audio/{unbind,bind}).
+"""
+
+import glob
+import logging
+import os
+from pathlib import Path
+
+from .constants import SCUF_VENDOR_ID, SCUF_PRODUCT_ID_WIRED, SCUF_PRODUCT_ID_RECEIVER
+
+log = logging.getLogger(__name__)
+
+SND_USB_AUDIO_DRIVER = "/sys/bus/usb/drivers/snd-usb-audio"
+
+
+def _read_sysfs(path):
+    """Read a sysfs attribute, return empty string on failure."""
+    try:
+        return Path(path).read_text().strip()
+    except (OSError, IOError):
+        return ""
+
+
+def _match_scuf_vid_pid(sysfs_dir):
+    """Walk up from sysfs_dir to find idVendor/idProduct and check for SCUF match."""
+    target_vid = f"{SCUF_VENDOR_ID:04x}"
+    target_pids = {f"{SCUF_PRODUCT_ID_WIRED:04x}", f"{SCUF_PRODUCT_ID_RECEIVER:04x}"}
+
+    check = sysfs_dir
+    for _ in range(10):
+        check = os.path.dirname(check)
+        if not check or check == "/":
+            break
+        vid_path = os.path.join(check, "idVendor")
+        pid_path = os.path.join(check, "idProduct")
+        if os.path.isfile(vid_path) and os.path.isfile(pid_path):
+            vid = _read_sysfs(vid_path)
+            pid = _read_sysfs(pid_path)
+            return vid == target_vid and pid in target_pids
+    return False
+
+
+def _find_scuf_audio_interfaces(bound_only=True):
+    """
+    Find USB interface identifiers for SCUF audio devices.
+
+    Args:
+        bound_only: If True, only return interfaces currently bound to
+                    snd-usb-audio. If False, scan all USB interfaces for
+                    SCUF audio-class devices (bound or not).
+
+    Returns:
+        List of interface identifiers (e.g. "3-2:1.0") suitable for
+        writing to unbind/bind.
+    """
+    results = []
+
+    if bound_only:
+        if not os.path.isdir(SND_USB_AUDIO_DRIVER):
+            log.debug("snd-usb-audio driver directory not found")
+            return []
+
+        for entry in os.listdir(SND_USB_AUDIO_DRIVER):
+            entry_path = os.path.join(SND_USB_AUDIO_DRIVER, entry)
+            if not os.path.islink(entry_path):
+                continue
+            real = os.path.realpath(entry_path)
+            if _match_scuf_vid_pid(real):
+                results.append(entry)
+                log.debug("Found bound SCUF audio interface: %s", entry)
+    else:
+        # Scan all USB interfaces for bInterfaceClass=01 (USB Audio)
+        for intf_dir in glob.glob("/sys/bus/usb/devices/*:*"):
+            intf_class = _read_sysfs(os.path.join(intf_dir, "bInterfaceClass"))
+            if intf_class != "01":
+                continue
+            parent = os.path.dirname(intf_dir)
+            target_vid = f"{SCUF_VENDOR_ID:04x}"
+            target_pids = {f"{SCUF_PRODUCT_ID_WIRED:04x}", f"{SCUF_PRODUCT_ID_RECEIVER:04x}"}
+            vid = _read_sysfs(os.path.join(parent, "idVendor"))
+            pid = _read_sysfs(os.path.join(parent, "idProduct"))
+            if vid == target_vid and pid in target_pids:
+                intf_id = os.path.basename(intf_dir)
+                results.append(intf_id)
+                log.debug("Found SCUF USB audio interface: %s", intf_id)
+
+    return results
+
+
+def unbind_scuf_audio():
+    """
+    Unbind all SCUF audio interfaces from snd-usb-audio.
+
+    Returns the number of interfaces unbound.
+    """
+    interfaces = _find_scuf_audio_interfaces(bound_only=True)
+    if not interfaces:
+        log.info("No SCUF audio interfaces currently bound to snd-usb-audio")
+        return 0
+
+    unbind_path = os.path.join(SND_USB_AUDIO_DRIVER, "unbind")
+    count = 0
+    for intf_id in interfaces:
+        try:
+            with open(unbind_path, "w") as f:
+                f.write(intf_id)
+            log.info("Unbound SCUF audio interface: %s", intf_id)
+            count += 1
+        except OSError as e:
+            log.error("Failed to unbind %s: %s", intf_id, e)
+
+    return count
+
+
+def rebind_scuf_audio():
+    """
+    Rebind SCUF audio interfaces to snd-usb-audio.
+
+    Finds unbound SCUF USB audio-class interfaces and writes them to the
+    driver's bind file.
+
+    Returns the number of interfaces rebound.
+    """
+    all_interfaces = _find_scuf_audio_interfaces(bound_only=False)
+    bound_interfaces = set(_find_scuf_audio_interfaces(bound_only=True))
+    unbound = [i for i in all_interfaces if i not in bound_interfaces]
+
+    if not unbound:
+        log.info("All SCUF audio interfaces already bound (or device not connected)")
+        return 0
+
+    bind_path = os.path.join(SND_USB_AUDIO_DRIVER, "bind")
+    count = 0
+    for intf_id in unbound:
+        try:
+            with open(bind_path, "w") as f:
+                f.write(intf_id)
+            log.info("Rebound SCUF audio interface: %s", intf_id)
+            count += 1
+        except OSError as e:
+            log.error("Failed to rebind %s: %s", intf_id, e)
+
+    return count
+
+
+def apply_audio_config():
+    """
+    Read config and apply the audio disabled/enabled state.
+
+    Called at driver startup and on wireless reconnect.
+    """
+    from .config import is_audio_disabled
+
+    if is_audio_disabled():
+        n = unbind_scuf_audio()
+        if n > 0:
+            log.info("Audio disabled: unbound %d SCUF audio interface(s)", n)
+        else:
+            log.info("Audio disabled in config (no interfaces to unbind)")
+    else:
+        n = rebind_scuf_audio()
+        if n > 0:
+            log.info("Audio enabled: rebound %d SCUF audio interface(s)", n)

--- a/scuf_envision/bridge.py
+++ b/scuf_envision/bridge.py
@@ -253,6 +253,12 @@ class BridgeService:
                 self.discovered = discovered
                 try:
                     self._open_devices()
+                    # Re-apply audio config on reconnection
+                    from .audio_control import apply_audio_config
+                    try:
+                        apply_audio_config()
+                    except Exception:
+                        pass
                     return True
                 except OSError as e:
                     log.warning(f"Device found but failed to open: {e}")
@@ -293,6 +299,13 @@ def run():
         sys.exit(1)
 
     log.info(f"Found controller: {discovered}")
+
+    # Apply audio config (disable/enable USB audio per /etc/scuf-envision/config.ini)
+    from .audio_control import apply_audio_config
+    try:
+        apply_audio_config()
+    except Exception as e:
+        log.warning(f"Could not apply audio config: {e}")
 
     # Enable reconnection for wireless connections
     reconnect = (discovered.connection_type == "wireless")

--- a/scuf_envision/config.py
+++ b/scuf_envision/config.py
@@ -1,0 +1,61 @@
+"""
+Configuration file management for SCUF Envision Pro V2 driver.
+
+Config path: /etc/scuf-envision/config.ini
+"""
+
+import configparser
+import logging
+import os
+
+log = logging.getLogger(__name__)
+
+CONFIG_DIR = "/etc/scuf-envision"
+CONFIG_PATH = os.path.join(CONFIG_DIR, "config.ini")
+
+DEFAULTS = {
+    "audio": {
+        "disabled": "false",
+    },
+}
+
+
+def load_config():
+    """Load config from disk, falling back to defaults if file is missing or malformed."""
+    config = configparser.ConfigParser()
+    for section, values in DEFAULTS.items():
+        config[section] = dict(values)
+
+    if os.path.isfile(CONFIG_PATH):
+        try:
+            config.read(CONFIG_PATH)
+            log.debug("Loaded config from %s", CONFIG_PATH)
+        except configparser.Error as e:
+            log.warning("Malformed config at %s, using defaults: %s", CONFIG_PATH, e)
+    else:
+        log.debug("No config file at %s, using defaults", CONFIG_PATH)
+
+    return config
+
+
+def save_config(config):
+    """Write config to disk, creating directory if needed."""
+    os.makedirs(CONFIG_DIR, mode=0o755, exist_ok=True)
+    with open(CONFIG_PATH, "w") as f:
+        config.write(f)
+    log.info("Saved config to %s", CONFIG_PATH)
+
+
+def is_audio_disabled():
+    """Return True if audio.disabled is set to true in config."""
+    config = load_config()
+    return config.getboolean("audio", "disabled", fallback=False)
+
+
+def set_audio_disabled(disabled):
+    """Set the audio.disabled flag and persist to disk."""
+    config = load_config()
+    if "audio" not in config:
+        config["audio"] = {}
+    config["audio"]["disabled"] = str(disabled).lower()
+    save_config(config)

--- a/tools/scuf-audio-toggle
+++ b/tools/scuf-audio-toggle
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""
+Toggle SCUF Envision Pro V2 USB audio on/off.
+
+Usage:
+    scuf-audio-toggle              Show current state
+    scuf-audio-toggle status       Same as above
+    scuf-audio-toggle disable      Disable audio (unbind from kernel)
+    scuf-audio-toggle enable       Enable audio (rebind to kernel)
+
+Requires root. Reads/writes /etc/scuf-envision/config.ini and
+immediately applies the change by unbinding/rebinding snd-usb-audio.
+"""
+
+import logging
+import os
+import sys
+
+# Allow running from install location (/opt/scuf-envision/tools/)
+# or from the repo checkout
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from scuf_envision.config import is_audio_disabled, set_audio_disabled, CONFIG_PATH
+from scuf_envision.audio_control import (
+    unbind_scuf_audio,
+    rebind_scuf_audio,
+    _find_scuf_audio_interfaces,
+)
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    if os.geteuid() != 0:
+        print("Error: must run as root (sudo scuf-audio-toggle)")
+        sys.exit(1)
+
+    args = sys.argv[1:]
+    command = args[0] if args else "status"
+
+    if command == "status":
+        disabled = is_audio_disabled()
+        bound = _find_scuf_audio_interfaces(bound_only=True)
+        all_intf = _find_scuf_audio_interfaces(bound_only=False)
+
+        print(f"Config:  {CONFIG_PATH}")
+        print(f"Setting: audio.disabled = {str(disabled).lower()}")
+        print(f"State:   {len(bound)} of {len(all_intf)} audio interface(s) "
+              f"bound to snd-usb-audio")
+        if disabled and bound:
+            print("WARNING: Config says disabled but interfaces are still bound.")
+            print("         Run: sudo scuf-audio-toggle disable")
+        elif not disabled and all_intf and not bound:
+            print("WARNING: Config says enabled but no interfaces are bound.")
+            print("         Run: sudo scuf-audio-toggle enable")
+
+    elif command == "disable":
+        set_audio_disabled(True)
+        n = unbind_scuf_audio()
+        print(f"Audio disabled. Unbound {n} interface(s).")
+        if n == 0:
+            print("(No SCUF audio interfaces were bound — device may not be connected.)")
+            print("Audio will remain disabled on next connect.")
+
+    elif command == "enable":
+        set_audio_disabled(False)
+        n = rebind_scuf_audio()
+        print(f"Audio enabled. Rebound {n} interface(s).")
+        if n == 0:
+            print("(No unbound SCUF audio interfaces found — already enabled "
+                  "or device not connected.)")
+            print("Audio will be enabled on next connect.")
+
+    else:
+        print(f"Unknown command: {command}")
+        print("Usage: scuf-audio-toggle [status|disable|enable]")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -13,26 +13,51 @@ if [ "$EUID" -ne 0 ]; then
     exit 1
 fi
 
-echo "[1/3] Stopping and disabling service..."
+echo "[1/6] Stopping and disabling service..."
 systemctl stop scuf-envision.service 2>/dev/null || true
 systemctl disable scuf-envision.service 2>/dev/null || true
 rm -f /etc/systemd/system/scuf-envision.service
 systemctl daemon-reload
 
-echo "[2/4] Removing udev rules..."
+echo "[2/6] Re-enabling SCUF audio if it was disabled..."
+if [ -f /etc/scuf-envision/config.ini ]; then
+    if python3 -c "
+import configparser, sys
+c = configparser.ConfigParser()
+c.read('/etc/scuf-envision/config.ini')
+sys.exit(0 if c.getboolean('audio', 'disabled', fallback=False) else 1)
+" 2>/dev/null; then
+        python3 -c "
+import sys; sys.path.insert(0, '/opt/scuf-envision')
+from scuf_envision.audio_control import rebind_scuf_audio
+rebind_scuf_audio()
+" 2>/dev/null && echo "  Re-enabled SCUF audio (was disabled)" || echo "  Could not re-enable audio (device may not be connected)"
+    else
+        echo "  Audio was not disabled, nothing to do"
+    fi
+else
+    echo "  No config file found, skipping"
+fi
+
+echo "[3/6] Removing udev rules..."
 rm -f /etc/udev/rules.d/99-scuf-envision.rules
 udevadm control --reload-rules
 
-echo "[3/4] Removing audio configs..."
+echo "[4/6] Removing audio configs..."
 rm -f /etc/wireplumber/wireplumber.conf.d/50-scuf-audio.conf
 rm -f /etc/wireplumber/wireplumber.conf.d/50-scuf-gain.conf   # legacy, from older installs
 rm -f /etc/pipewire/pipewire.conf.d/50-scuf-gain.conf         # legacy, from older installs
 echo "  Removed WirePlumber and PipeWire audio configs (if present)"
 
-echo "[4/4] Removing installed files..."
+echo "[5/6] Removing CLI tool symlink..."
+rm -f /usr/local/bin/scuf-audio-toggle
+
+echo "[6/6] Removing installed files..."
 rm -rf /opt/scuf-envision
 
 echo ""
 echo "Uninstall complete."
 echo "Note: python-evdev and uinput module were not removed."
+echo "Note: /etc/scuf-envision/ was preserved. Remove manually if desired:"
+echo "  sudo rm -rf /etc/scuf-envision"
 echo "Restart PipeWire/WirePlumber or reboot to apply audio changes."


### PR DESCRIPTION
## Summary
This PR adds the ability to completely disable or enable USB audio on the SCUF Envision Pro V2 controller by unbinding/rebinding the `snd-usb-audio` kernel driver. This allows users to prevent the controller's headphone jack from appearing as an audio device in the system.

## Key Changes

- **New `audio_control.py` module**: Implements kernel driver binding/unbinding logic
  - `unbind_scuf_audio()`: Unbinds SCUF audio interfaces from snd-usb-audio driver
  - `rebind_scuf_audio()`: Rebinds unbound SCUF audio interfaces
  - `apply_audio_config()`: Applies the audio disabled/enabled state from config at startup and on reconnect
  - Helper functions to find SCUF audio interfaces by scanning sysfs and matching vendor/product IDs

- **New `config.py` module**: Configuration file management
  - Reads/writes `/etc/scuf-envision/config.ini` with INI format
  - Provides `is_audio_disabled()` and `set_audio_disabled()` functions
  - Falls back to sensible defaults if config file is missing or malformed

- **New `scuf-audio-toggle` CLI tool**: User-facing command-line interface
  - `scuf-audio-toggle status`: Show current audio state and config setting
  - `scuf-audio-toggle disable`: Disable audio and persist setting
  - `scuf-audio-toggle enable`: Enable audio and persist setting
  - Requires root; installed to `/usr/local/bin/` with symlink

- **New `config.ini.default`**: Default configuration template with documentation

- **Updated `bridge.py`**: Integrates audio config application
  - Calls `apply_audio_config()` at driver startup
  - Re-applies audio config on wireless reconnection

- **Updated installation/uninstallation scripts**:
  - Install default config to `/etc/scuf-envision/config.ini`
  - Install and symlink the CLI tool
  - Re-enable audio on uninstall if it was disabled
  - Updated step counts and added user-facing instructions

## Implementation Details

- Uses sysfs to interact with the kernel driver (requires root)
- Scans `/sys/bus/usb/drivers/snd-usb-audio/` to find bound interfaces
- Walks up sysfs directory tree to match SCUF vendor/product IDs
- Supports both wired (0x3a05) and wireless receiver (0x3a08) product IDs
- Audio state persists across reboots via config file
- Gracefully handles missing device or already-bound/unbound states

https://claude.ai/code/session_016mANWPzot8ESj9Yaiacr9h