### PR TITLE
feat(input): add OLH-style piecewise-linear response curves for stick…

### DIFF
--- a/config.ini.default
+++ b/config.ini.default
@@ -127,6 +127,35 @@ right_stick_anti_deadzone = 0
 # For Hall Effect sticks: 16–32. For worn potentiometers: 64–128.
 jitter_threshold = 32
 
+# ── Response curves ───────────────────────────────────────────────────────────
+# Shape the analog output for sticks and triggers using piecewise-linear
+# interpolation through 6 control points (OLH-compatible format).
+#
+# Options: linear, aggressive, steady, relaxed, custom
+#
+#   linear     — 1:1 mapping (default, current behaviour)
+#   aggressive — fast initial response; reaches max deflection sooner
+#                (good for fast-paced games where you want quick full deflection)
+#   steady     — more precision near centre; gradual buildup to max
+#                (good for aiming, slower-paced games)
+#   relaxed    — maximum centre precision; very slow buildup
+#                (best for precision aiming at the cost of quick max deflection)
+#   custom     — define your own 6-point curve below
+#
+# Per-profile: add stick_response_curve / trigger_response_curve under
+# a [profile.NAME.input] section to override per game.
+stick_response_curve = linear
+trigger_response_curve = linear
+
+# Custom curve control points (only used when curve = custom).
+# Twelve comma-separated integers: x0,y0,x1,y1,...,x5,y5
+# x = input percentage (0–100), y = output percentage (0–100).
+# Points must be in ascending x order; first must be (0,0), last (100,100).
+# Example (linear): 0,0,20,20,40,40,60,60,80,80,100,100
+# Example (aggressive ≈ sqrt): 0,0,20,42,40,65,60,80,80,92,100,100
+# stick_curve_points = 0,0,20,20,40,40,60,60,80,80,100,100
+# trigger_curve_points = 0,0,20,20,40,40,60,60,80,80,100,100
+
 [driver]
 # Event loop poll timeout in milliseconds.
 # Default 2 matches the controller's 500 Hz report rate (wired + Slipstream wireless).

--- a/scuf_envision/bridge.py
+++ b/scuf_envision/bridge.py
@@ -354,6 +354,8 @@ class BridgeService:
             left_trigger_deadzone=p['left_trigger_deadzone_sw'],
             right_trigger_deadzone=p['right_trigger_deadzone_sw'],
             jitter_threshold=p['jitter_threshold'],
+            stick_curve=p['stick_curve'],
+            trigger_curve=p['trigger_curve'],
         )
         log.debug("Input filter reloaded: L_sw=%d R_sw=%d L_anti=%d R_anti=%d jitter=%d",
                   p['left_stick_deadzone_sw'], p['right_stick_deadzone_sw'],

--- a/scuf_envision/config.py
+++ b/scuf_envision/config.py
@@ -70,6 +70,8 @@ DEFAULTS = {
         "left_trigger_deadzone_sw":  "5",
         "right_trigger_deadzone_sw": "5",
         "jitter_threshold":          "32",
+        "stick_response_curve":      "linear",
+        "trigger_response_curve":    "linear",
     },
 }
 
@@ -261,6 +263,19 @@ def rgb_state_params(state: str, profile_name: str | None = None) -> dict:
                 speed=speed, brightness=brightness)
 
 
+def _parse_curve(name: str, points_str: str | None) -> list:
+    """Resolve a curve name (or 'custom') to a list of 6 (x%, y%) tuples."""
+    from .input_filter import CURVE_PRESETS
+    if name == 'custom' and points_str:
+        try:
+            vals = [int(v.strip()) for v in points_str.split(',')]
+            if len(vals) == 12:
+                return list(zip(vals[::2], vals[1::2]))
+        except ValueError:
+            pass
+    return CURVE_PRESETS.get(name, CURVE_PRESETS['linear'])
+
+
 def input_params(profile_name: str | None = None) -> dict:
     """Return input filter configuration, with optional per-profile override.
 
@@ -277,6 +292,11 @@ def input_params(profile_name: str | None = None) -> dict:
         except ValueError:
             return default
 
+    stick_curve_name    = config.get(section, "stick_response_curve",   fallback="linear").strip()
+    trigger_curve_name  = config.get(section, "trigger_response_curve", fallback="linear").strip()
+    stick_pts_raw       = config.get(section, "stick_curve_points",     fallback=None)
+    trigger_pts_raw     = config.get(section, "trigger_curve_points",   fallback=None)
+
     return {
         "left_stick_deadzone_hw":    gi("left_stick_deadzone_hw",    2,   0, 15),
         "right_stick_deadzone_hw":   gi("right_stick_deadzone_hw",   2,   0, 15),
@@ -289,6 +309,8 @@ def input_params(profile_name: str | None = None) -> dict:
         "left_trigger_deadzone_sw":  gi("left_trigger_deadzone_sw",  5,   0, 1023),
         "right_trigger_deadzone_sw": gi("right_trigger_deadzone_sw", 5,   0, 1023),
         "jitter_threshold":          gi("jitter_threshold",          32,  0, 1000),
+        "stick_curve":               _parse_curve(stick_curve_name,   stick_pts_raw),
+        "trigger_curve":             _parse_curve(trigger_curve_name, trigger_pts_raw),
     }
 
 

--- a/scuf_envision/input_filter.py
+++ b/scuf_envision/input_filter.py
@@ -1,5 +1,6 @@
 """
-Input filtering: radial deadzone, trigger deadzone, anti-deadzone, and jitter suppression.
+Input filtering: radial deadzone, trigger deadzone, anti-deadzone, jitter suppression,
+and piecewise-linear response curves (OLH-compatible 6-point format).
 """
 
 import math
@@ -7,6 +8,35 @@ from .constants import (
     STICK_DEADZONE, TRIGGER_DEADZONE, STICK_JITTER_THRESHOLD,
     STICK_MIN, STICK_MAX, TRIGGER_MIN, TRIGGER_MAX,
 )
+
+# Six (input%, output%) control points — same format as OpenLinkHub's AnalogData.Points.
+# x=input percentage (0-100), y=output percentage (0-100).
+CURVE_PRESETS = {
+    'linear':     [(0,0),(20,20),(40,40),(60,60),(80,80),(100,100)],
+    'aggressive': [(0,0),(20,42),(40,65),(60,80),(80,92),(100,100)],  # ~power 0.5
+    'steady':     [(0,0),(20,5), (40,18),(60,40),(80,68),(100,100)],  # ~power 2
+    'relaxed':    [(0,0),(20,2), (40,10),(60,28),(80,58),(100,100)],  # ~power 3
+}
+
+
+def _apply_curve(t: float, points: list) -> float:
+    """Piecewise linear interpolation through curve control points.
+
+    t is the normalized input in [0, 1]; points are (x%, y%) pairs in [0, 100].
+    Returns the shaped output in [0, 1].
+    """
+    if t <= 0.0:
+        return 0.0
+    if t >= 1.0:
+        return 1.0
+    t100 = t * 100.0
+    for i in range(len(points) - 1):
+        x0, y0 = points[i]
+        x1, y1 = points[i + 1]
+        if x0 <= t100 <= x1:
+            alpha = (t100 - x0) / (x1 - x0) if x1 != x0 else 0.0
+            return (y0 + alpha * (y1 - y0)) / 100.0
+    return t
 
 
 class InputFilter:
@@ -19,7 +49,9 @@ class InputFilter:
                  right_stick_anti_dz: int = 0,
                  left_trigger_deadzone: int = TRIGGER_DEADZONE,
                  right_trigger_deadzone: int = TRIGGER_DEADZONE,
-                 jitter_threshold: int = STICK_JITTER_THRESHOLD):
+                 jitter_threshold: int = STICK_JITTER_THRESHOLD,
+                 stick_curve: list = None,
+                 trigger_curve: list = None):
         self.left_stick_deadzone = left_stick_deadzone
         self.right_stick_deadzone = right_stick_deadzone
         self.left_stick_anti_dz = left_stick_anti_dz
@@ -27,6 +59,8 @@ class InputFilter:
         self.left_trigger_deadzone = left_trigger_deadzone
         self.right_trigger_deadzone = right_trigger_deadzone
         self.jitter_threshold = jitter_threshold
+        self.stick_curve = stick_curve if stick_curve is not None else CURVE_PRESETS['linear']
+        self.trigger_curve = trigger_curve if trigger_curve is not None else CURVE_PRESETS['linear']
 
         # Last output values for jitter suppression
         self._last = {}
@@ -49,8 +83,9 @@ class InputFilter:
         if magnitude < deadzone:
             return 0, 0
 
-        # Scale so deadzone edge → 0, max deflection → STICK_MAX
+        # Scale so deadzone edge → 0, max deflection → STICK_MAX, then shape
         scale = min((magnitude - deadzone) / (STICK_MAX - deadzone), 1.0)
+        scale = _apply_curve(scale, self.stick_curve)
 
         if magnitude > 0:
             nx, ny = x / magnitude, y / magnitude
@@ -85,9 +120,12 @@ class InputFilter:
         return sign * min(scaled, STICK_MAX)
 
     def filter_trigger(self, value: int, side: str = 'left') -> int:
-        """Apply deadzone to a trigger value."""
+        """Apply deadzone and response curve to a trigger value."""
         deadzone = self.left_trigger_deadzone if side == 'left' else self.right_trigger_deadzone
-        return 0 if value < deadzone else value
+        if value < deadzone:
+            return 0
+        t = (value - deadzone) / (TRIGGER_MAX - deadzone)
+        return int(_apply_curve(t, self.trigger_curve) * TRIGGER_MAX)
 
     def suppress_jitter(self, key: str, new_value: int) -> tuple:
         """


### PR DESCRIPTION
…s and triggers

Implements the same 6-point (x%, y%) control-point format used by OpenLinkHub's AnalogData.Points in software, via piecewise-linear interpolation on the normalised input magnitude/value.

Four named presets:
  linear     — 1:1 mapping (default, identical to previous behaviour)
  aggressive — ~sqrt shape; fast initial response, quick to max deflection
  steady     — ~quadratic; more precision near centre, gradual buildup
  relaxed    — ~cubic; maximum centre precision, slow buildup

Triggers now normalise their post-deadzone range to [0,1] before applying the curve, eliminating the previous step discontinuity at the deadzone edge.

Config keys (global [input] or per-profile [profile.NAME.input]):
  stick_response_curve   = linear|aggressive|steady|relaxed|custom
  trigger_response_curve = linear|aggressive|steady|relaxed|custom
  stick_curve_points     = 0,0,20,20,...  (custom only, 12 values)
  trigger_curve_points   = 0,0,20,20,...  (custom only, 12 values)

https://claude.ai/code/session_019u3aVqBeyMMPaKEN6onVQn