### PR TITLE
fix(tray): fix D-Bus object path (hyphen→underscore) and catch Blocki…

### DIFF
--- a/tools/tray.py
+++ b/tools/tray.py
@@ -47,7 +47,7 @@ def _ipc(cmd: str):
             return b"".join(chunks).decode().strip()
     except (FileNotFoundError, ConnectionRefusedError):
         return _OFFLINE
-    except TimeoutError:
+    except (TimeoutError, BlockingIOError):
         return _TIMEOUT
     except OSError as e:
         log.debug("IPC error for %r: %s", cmd, e)
@@ -91,7 +91,7 @@ class TrayApp:
         self._ipc_error = _OFFLINE   # last _ipc sentinel (or None if OK)
         self._lock = threading.Lock()
         self._icon = pystray.Icon(
-            "scuf-envision",
+            "scuf_envision",
             ICON_OFFLINE,
             "SCUF Envision — offline",
             menu=pystray.Menu(self._build_menu),


### PR DESCRIPTION
…ngIOError

pystray uses the icon name as a D-Bus object path component; hyphens are illegal so the indicator never registered, leaving the tray blank. Also catch BlockingIOError alongside TimeoutError — on Linux, SO_RCVTIMEO expiry raises EAGAIN which maps to BlockingIOError, not TimeoutError.

https://claude.ai/code/session_019u3aVqBeyMMPaKEN6onVQn