### PR TITLE
fix(tray): start poll thread via pystray setup callback to avoid GTK …

### DIFF
--- a/tools/tray.py
+++ b/tools/tray.py
@@ -227,8 +227,9 @@ class TrayApp:
     # ── entry point ───────────────────────────────────────────────────────────
 
     def run(self) -> None:
-        threading.Thread(target=self._poll_loop, daemon=True).start()
-        self._icon.run()
+        def _start_poll(icon):
+            threading.Thread(target=self._poll_loop, daemon=True).start()
+        self._icon.run(setup=_start_poll)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…init race

The poll thread was starting before pystray's GTK/AppIndicator D-Bus registration completed. _refresh_icon() then tried to emit a D-Bus signal on an object with no valid path yet, causing the GLib-GIO-CRITICAL assertion. Using the setup= callback guarantees the poll thread only starts after the indicator is fully registered.

https://claude.ai/code/session_019u3aVqBeyMMPaKEN6onVQn