### PR TITLE
docs: mark Phase 15 complete, add Phase 21 (config GUI), fix pystray …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,12 +63,13 @@ up to 5 min while waiting for controller reconnection.
 | 12 | RGB control | ✅ | `scuf_envision/hid.py`, `scuf_envision/constants.py`, `scuf_envision/config.py` |
 | 13 | Vibration/haptics passthrough | ✅ | `scuf_envision/rumble.py`, `scuf_envision/hid.py`, `virtual_gamepad.py` |
 | 14 | Analog deadzone config (SW per-stick, anti-deadzone, per-profile; HW deadzones blocked pending USB capture verification) | ✅ | `scuf_envision/constants.py`, `scuf_envision/hid.py`, `scuf_envision/input_filter.py`, `scuf_envision/config.py`, `bridge.py` |
-| 15 | Tray app | Planned | `tools/tray.py` (new) |
+| 15 | Tray app (PyQt6 QSystemTrayIcon; connection/battery status, profile switcher, RGB shortcuts) | ✅ | `tools/tray.py` |
 | 16 | Layers — per-profile layer stack, paddle/button layer switching, layer-switch `notify-send` with layer name | Planned | `bridge.py`, `scuf_envision/config.py` |
 | 17 | Macros — button-to-sequence bindings per layer, delay support | Planned | `bridge.py`, `scuf_envision/config.py` |
 | 18 | Desktop layer — persistent global base layer across all profiles; lower priority than profile bindings; intended for window switching, media keys, etc. | Planned | `bridge.py`, `scuf_envision/config.py` |
 | 19 | OSK integration — invoke system on-screen keyboard from a button bind | Blocked | `bridge.py` — waiting on xdg-desktop-portal gamepad input portal |
 | 20 | DS4 emulation — configurable virtual device target (Xbox / DS4 / DualSense); changes VID:PID and button layout of uinput device; enables PS button prompts in games; per-profile override supported | Planned | `scuf_envision/virtual_gamepad.py`, `scuf_envision/config.py` |
+| 21 | Config GUI — PyQt6 settings window; edit all profiles, button remaps, deadzones, response curves, RGB, triggers; create/clone/delete profiles; live apply via IPC; "Open Settings" entry in tray menu | Planned | `tools/scuf-settings.py` (new), `tools/tray.py` |
 
 ## Known Platform Constraints
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ sudo bash install.sh
 ```
 
 This does everything automatically:
-- Installs dependencies: `python-evdev`, `libnotify`, `pystray`, `pillow`
+- Installs dependencies: `python-evdev`, `libnotify`, `python-pyqt6`, `pillow`
 - Loads the `uinput` kernel module (persists across reboots)
 - Installs udev rules (device permissions + hardware mixer init on plug)
 - Copies the driver to `/opt/scuf-envision`
@@ -457,12 +457,12 @@ scuf-tray
 
 The tray icon reflects driver state:
 - **Green** — controller connected (wired)
-- **Yellow** — controller connected (wireless)
+- **Teal** — controller connected (wireless)
 - **Red** — driver offline or searching for controller
 
 The menu shows connection status, battery level (when available), a profile switcher, and RGB shortcuts. The icon title includes the active profile name.
 
-> Requires `pystray` and `pillow` (`pip install pystray pillow` if not installed by the installer).
+> Requires `PyQt6` and `pillow` (installed automatically by `install.sh`).
 
 ### scuf-audio-toggle
 
@@ -592,13 +592,13 @@ Reboot after removal.
 
 ```bash
 # Arch/Garuda
-sudo pacman -S python-evdev python-pystray python-pillow
+sudo pacman -S python-evdev python-pyqt6 python-pillow
 
 # Ubuntu/Debian
-sudo apt install python3-evdev python3-pil && pip install pystray
+sudo apt install python3-evdev python3-pyqt6 python3-pil
 
 # Fedora
-sudo dnf install python3-evdev python3-pillow && pip install pystray
+sudo dnf install python3-evdev python3-pillow && pip install PyQt6
 
 # Load uinput
 sudo modprobe uinput
@@ -698,7 +698,7 @@ scuf-envision-pro-V2-Linux/
     scuf-audio-toggle   # CLI: disable/enable SCUF audio
     scuf-ctl            # CLI: IPC client (profile switch, RGB, status, ping)
     scuf-profile        # Launch wrapper: activate profile, restore on exit
-    tray.py             # System tray app (pystray + pillow)
+    tray.py             # System tray app (PyQt6 + pillow)
     scuf-tray.desktop   # XDG autostart entry for tray app
   config.ini.default    # Default config template
   50-scuf-audio.conf    # WirePlumber config for headphone audio
@@ -719,6 +719,7 @@ scuf-envision-pro-V2-Linux/
 | 18 | **Desktop layer** — persistent base layer across all profiles for window switching, media keys, etc. |
 | 19 | **On-screen keyboard** — invoke system OSK from a button bind *(blocked: waiting on xdg-desktop-portal gamepad input portal)* |
 | 20 | **DS4 / DualSense emulation** — optional alternative virtual device target; shows PlayStation button prompts in games |
+| 21 | **Config GUI** — PyQt6 settings window for editing profiles, button remaps, deadzones, response curves, RGB, and triggers without touching config files; live apply via IPC |
 
 ---
 


### PR DESCRIPTION
…→ PyQt6 refs

CLAUDE.md: Phase 15 → ✅; add Phase 21 (PyQt6 settings window). README.md: wireless icon yellow → teal; pystray → PyQt6 throughout (installer deps, manual install, project structure, tray requires note); add Phase 21 to planned features table.

https://claude.ai/code/session_019u3aVqBeyMMPaKEN6onVQn