### PR TITLE
fix(paddles): read secondary evdev device so paddle events reach the …

### DIFF
--- a/config.ini.default
+++ b/config.ini.default
@@ -192,15 +192,16 @@ poll_timeout_ms = 2
 #   BTN_TL2             = L3 — left stick click (SCUF quirk)
 #   BTN_TR2             = R3 — right stick click (SCUF quirk)
 #   BTN_MODE            = Guide / Xbox button
-#   BTN_TRIGGER_HAPPY1  = Paddle 1
-#   BTN_TRIGGER_HAPPY2  = Paddle 2
-#   BTN_TRIGGER_HAPPY3  = Paddle 3
+#   BTN_TRIGGER_HAPPY1  = Paddle 1 (bottom-left)
+#   BTN_TRIGGER_HAPPY2  = Paddle 2 (bottom-right)
+#   BTN_TRIGGER_HAPPY3  = Paddle 3 (top-left)
+#   BTN_TRIGGER_HAPPY4  = Paddle 4 (top-right)
 #
 # Virtual output codes (what games see after remapping):
 #   BTN_SOUTH  = A    BTN_NORTH  = X    BTN_TL    = LB    BTN_SELECT  = Back
 #   BTN_EAST   = B    BTN_WEST   = Y    BTN_TR    = RB    BTN_START   = Start
 #   BTN_THUMBL = L3   BTN_THUMBR = R3   BTN_MODE  = Guide
-#   BTN_TRIGGER_HAPPY1/2/3 = Paddles (pass-through)
+#   BTN_TRIGGER_HAPPY1/2/3/4 = Paddles (pass-through)
 #
 # Run 'scuf-ctl status' to see the active profile.
 # Run 'scuf-ctl profile NAME' to switch profiles without restarting.

--- a/scuf_envision/bridge.py
+++ b/scuf_envision/bridge.py
@@ -62,6 +62,7 @@ class BridgeService:
         self._sleep_after: float = 300.0
         self._physical = None
         self._grabbed_devices = []
+        self._secondary_devices: list = []
         self._running = False
         self._profile: ProfileManager | None = None
         self._ipc: IPCServer | None = ipc_server
@@ -168,7 +169,8 @@ class BridgeService:
                 sec_dev = evdev.InputDevice(sec_path)
                 sec_dev.grab()
                 self._grabbed_devices.append(sec_dev)
-                log.debug("Grabbed secondary: %s", sec_path)
+                self._secondary_devices.append(sec_dev)
+                log.debug("Grabbed secondary: %s (%s)", sec_path, sec_dev.name)
             except (OSError, PermissionError) as e:
                 log.warning("Could not grab secondary device %s: %s", sec_path, e)
 
@@ -194,6 +196,10 @@ class BridgeService:
         poll.register(phys_fd, select.POLLIN)
         timeout = _poll_timeout_ms()
 
+        secondary_fd_map = {dev.fd: dev for dev in self._secondary_devices}
+        for fd in secondary_fd_map:
+            poll.register(fd, select.POLLIN)
+
         vgpad_fd = self.gamepad.fd if self._rumble else -1
         if vgpad_fd >= 0:
             poll.register(vgpad_fd, select.POLLIN)
@@ -216,6 +222,14 @@ class BridgeService:
                     except OSError as e:
                         if self._running:
                             log.error("Device read error: %s", e)
+                            raise _DeviceDisconnected() from e
+                elif ready_fd in secondary_fd_map:
+                    try:
+                        for event in secondary_fd_map[ready_fd].read():
+                            self._handle_secondary_event(event)
+                    except OSError as e:
+                        if self._running:
+                            log.error("Secondary device read error: %s", e)
                             raise _DeviceDisconnected() from e
                 elif ready_fd == vgpad_fd:
                     self._handle_ff_events()
@@ -240,19 +254,35 @@ class BridgeService:
             self.gamepad.syn()
 
     def _handle_button(self, event):
+        self._dispatch_button(event.code, event.value)
+
+    def _dispatch_button(self, code: int, value: int):
         """Remap and forward a button event via the active profile's button map."""
         sw_btn = self._profile.switch_button
-        if sw_btn is not None and event.code == sw_btn:
-            if event.value == 1:
+        if sw_btn is not None and code == sw_btn:
+            if value == 1:
                 layer = self._profile.cycle_layer()
                 if layer is not None:
                     self._on_layer_switch(layer)
             return  # consume key-down and key-up; never emit to virtual gamepad
-        mapped = self._profile.effective_button_map.get(event.code)
+        mapped = self._profile.effective_button_map.get(code)
         if mapped is not None:
-            self.gamepad.emit_button(mapped, event.value)
-        elif event.value == 1:
-            log.debug("Unknown button: code=0x%03x (%d)", event.code, event.code)
+            self.gamepad.emit_button(mapped, value)
+        elif value == 1:
+            log.debug("Unknown button: code=0x%03x (%d)", code, code)
+
+    def _handle_secondary_event(self, event):
+        """Pre-remap secondary device events (paddles as face codes → TRIGGER_HAPPY)."""
+        from .constants import SECONDARY_PADDLE_MAP
+        if event.type == ecodes.EV_SYN:
+            self.gamepad.syn()
+            return
+        if event.type != ecodes.EV_KEY:
+            return
+        code = SECONDARY_PADDLE_MAP.get(event.code)
+        if code is not None:
+            self._last_input_time = time.monotonic()
+            self._dispatch_button(code, event.value)
 
     def _handle_axis(self, event):
         from .constants import AXIS_MAP
@@ -458,6 +488,7 @@ class BridgeService:
             except OSError:
                 pass
         self._grabbed_devices.clear()
+        self._secondary_devices.clear()
         self._physical = None
 
     def _zero_virtual_outputs(self):

--- a/scuf_envision/constants.py
+++ b/scuf_envision/constants.py
@@ -40,11 +40,25 @@ BUTTON_MAP = {
     ecodes.BTN_MODE:           ecodes.BTN_MODE,           # Guide/Xbox button (correct)
 }
 
-# Paddle buttons (V2 has 3 physical paddles, maps to Xbox Elite paddle slots)
+# Paddle buttons — V2 has 4 physical paddles. The secondary evdev device reports
+# them as face button codes (BTN_SOUTH/EAST/C/NORTH). SECONDARY_PADDLE_MAP below
+# normalises them to unique BTN_TRIGGER_HAPPY codes before profile remapping.
 PADDLE_MAP = {
-    ecodes.BTN_TRIGGER_HAPPY1: ecodes.BTN_TRIGGER_HAPPY1,  # Paddle 1
-    ecodes.BTN_TRIGGER_HAPPY2: ecodes.BTN_TRIGGER_HAPPY2,  # Paddle 2
-    ecodes.BTN_TRIGGER_HAPPY3: ecodes.BTN_TRIGGER_HAPPY3,  # Paddle 3
+    ecodes.BTN_TRIGGER_HAPPY1: ecodes.BTN_TRIGGER_HAPPY1,  # Paddle 1 (bottom-left)
+    ecodes.BTN_TRIGGER_HAPPY2: ecodes.BTN_TRIGGER_HAPPY2,  # Paddle 2 (bottom-right)
+    ecodes.BTN_TRIGGER_HAPPY3: ecodes.BTN_TRIGGER_HAPPY3,  # Paddle 3 (top-left)
+    ecodes.BTN_TRIGGER_HAPPY4: ecodes.BTN_TRIGGER_HAPPY4,  # Paddle 4 (top-right)
+}
+
+# The secondary evdev device (grabbed by bridge, separate from the main gamepad
+# interface) emits face button codes for paddle presses because the controller
+# firmware binds paddles to face buttons by default. Pre-remap to unique codes
+# before the profile layer so paddles and face buttons are independently bindable.
+SECONDARY_PADDLE_MAP = {
+    ecodes.BTN_SOUTH:  ecodes.BTN_TRIGGER_HAPPY1,  # bottom-left paddle
+    ecodes.BTN_EAST:   ecodes.BTN_TRIGGER_HAPPY2,  # bottom-right paddle
+    ecodes.BTN_C:      ecodes.BTN_TRIGGER_HAPPY3,  # top-left paddle
+    ecodes.BTN_NORTH:  ecodes.BTN_TRIGGER_HAPPY4,  # top-right paddle
 }
 
 # --- Axis mapping ---


### PR DESCRIPTION
…bridge

The SCUF V2 exposes paddles on a separate HID interface that maps to a secondary evdev device. Previously that device was grabbed (silencing it from other apps) but never read — paddle presses were silently dropped.

- SECONDARY_PADDLE_MAP in constants.py: translates the face-button codes the firmware emits on the secondary device (BTN_SOUTH/EAST/C/NORTH) to unique BTN_TRIGGER_HAPPY1–4 codes before profile remapping applies. This keeps paddles and face buttons independently bindable.
- PADDLE_MAP gains BTN_TRIGGER_HAPPY4 (4th paddle, top-right).
- bridge._open_devices: secondary devices are also tracked in self._secondary_devices (separate from _grabbed_devices which also holds suppressed OLH gamepads).
- bridge._event_loop: secondary fds are registered in the poll and routed through _handle_secondary_event → SECONDARY_PADDLE_MAP → _dispatch_button.
- _handle_button refactored to delegate to _dispatch_button(code, value) so both primary and secondary paths share the same switch_button / profile-remap logic.
- _release_physical clears _secondary_devices alongside _grabbed_devices.

https://claude.ai/code/session_01TGkmjnkSJ5V6Pxa2SseZcT