### PR TITLE
Remove dead SECONDARY_PADDLE_MAP code; mark Phase 16 complete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ up to 5 min while waiting for controller reconnection.
 | 13 | Vibration/haptics passthrough | ✅ | `scuf_envision/rumble.py`, `scuf_envision/hid.py`, `virtual_gamepad.py` |
 | 14 | Analog deadzone config (SW per-stick, anti-deadzone, per-profile; HW deadzones blocked pending USB capture verification) | ✅ | `scuf_envision/constants.py`, `scuf_envision/hid.py`, `scuf_envision/input_filter.py`, `scuf_envision/config.py`, `bridge.py` |
 | 15 | Tray app (PyQt6 QSystemTrayIcon; connection/battery status, profile switcher, RGB shortcuts) | ✅ | `tools/tray.py` |
-| 16 | Layers — per-profile layer stack, paddle/button layer switching, layer-switch `notify-send` with layer name | Planned | `bridge.py`, `scuf_envision/config.py` |
+| 16 | Layers — per-profile layer stack, paddle/button layer switching, layer-switch `notify-send` with layer name | ✅ | `scuf_envision/profile.py`, `bridge.py`, `scuf_envision/ipc.py`, `tools/scuf-ctl` |
 | 17 | Macros — button-to-sequence bindings per layer, delay support | Planned | `bridge.py`, `scuf_envision/config.py` |
 | 18 | Desktop layer — persistent global base layer across all profiles; lower priority than profile bindings; intended for window switching, media keys, etc. | Planned | `bridge.py`, `scuf_envision/config.py` |
 | 19 | OSK integration — invoke system on-screen keyboard from a button bind | Blocked | `bridge.py` — waiting on xdg-desktop-portal gamepad input portal |

--- a/scuf_envision/bridge.py
+++ b/scuf_envision/bridge.py
@@ -225,8 +225,7 @@ class BridgeService:
                             raise _DeviceDisconnected() from e
                 elif ready_fd in secondary_fd_map:
                     try:
-                        for event in secondary_fd_map[ready_fd].read():
-                            self._handle_secondary_event(event)
+                        secondary_fd_map[ready_fd].read()  # drain; secondary devices emit no buttons
                     except OSError as e:
                         if self._running:
                             log.error("Secondary device read error: %s", e)
@@ -270,19 +269,6 @@ class BridgeService:
             self.gamepad.emit_button(mapped, value)
         elif value == 1:
             log.debug("Unknown button: code=0x%03x (%d)", code, code)
-
-    def _handle_secondary_event(self, event):
-        """Pre-remap secondary device events (paddles as face codes → TRIGGER_HAPPY)."""
-        from .constants import SECONDARY_PADDLE_MAP
-        if event.type == ecodes.EV_SYN:
-            self.gamepad.syn()
-            return
-        if event.type != ecodes.EV_KEY:
-            return
-        code = SECONDARY_PADDLE_MAP.get(event.code)
-        if code is not None:
-            self._last_input_time = time.monotonic()
-            self._dispatch_button(code, event.value)
 
     def _handle_axis(self, event):
         from .constants import AXIS_MAP

--- a/scuf_envision/constants.py
+++ b/scuf_envision/constants.py
@@ -40,25 +40,13 @@ BUTTON_MAP = {
     ecodes.BTN_MODE:           ecodes.BTN_MODE,           # Guide/Xbox button (correct)
 }
 
-# Paddle buttons — V2 has 4 physical paddles. The secondary evdev device reports
-# them as face button codes (BTN_SOUTH/EAST/C/NORTH). SECONDARY_PADDLE_MAP below
-# normalises them to unique BTN_TRIGGER_HAPPY codes before profile remapping.
+# Paddle buttons — V2 has 4 physical paddles. Currently firmware-bound to face
+# button HID usages; these entries are placeholders for post-firmware-reprogram codes.
 PADDLE_MAP = {
     ecodes.BTN_TRIGGER_HAPPY1: ecodes.BTN_TRIGGER_HAPPY1,  # Paddle 1 (bottom-left)
     ecodes.BTN_TRIGGER_HAPPY2: ecodes.BTN_TRIGGER_HAPPY2,  # Paddle 2 (bottom-right)
     ecodes.BTN_TRIGGER_HAPPY3: ecodes.BTN_TRIGGER_HAPPY3,  # Paddle 3 (top-left)
     ecodes.BTN_TRIGGER_HAPPY4: ecodes.BTN_TRIGGER_HAPPY4,  # Paddle 4 (top-right)
-}
-
-# The secondary evdev device (grabbed by bridge, separate from the main gamepad
-# interface) emits face button codes for paddle presses because the controller
-# firmware binds paddles to face buttons by default. Pre-remap to unique codes
-# before the profile layer so paddles and face buttons are independently bindable.
-SECONDARY_PADDLE_MAP = {
-    ecodes.BTN_SOUTH:  ecodes.BTN_TRIGGER_HAPPY1,  # bottom-left paddle
-    ecodes.BTN_EAST:   ecodes.BTN_TRIGGER_HAPPY2,  # bottom-right paddle
-    ecodes.BTN_C:      ecodes.BTN_TRIGGER_HAPPY3,  # top-left paddle
-    ecodes.BTN_NORTH:  ecodes.BTN_TRIGGER_HAPPY4,  # top-right paddle
 }
 
 # --- Axis mapping ---


### PR DESCRIPTION
All 4 paddles emit the same evdev codes as face buttons (confirmed via manual testing). SECONDARY_PADDLE_MAP was based on a false assumption that paddles come from a secondary evdev device — they don't. Secondary devices only emit ABS_MISC.

- Remove SECONDARY_PADDLE_MAP from constants.py
- Remove _handle_secondary_event from bridge.py (unreachable dead code)
- Secondary devices are still grabbed and drained to suppress OLH conflicts
- Phase 16 (Layers) is fully implemented; mark ✅ in CLAUDE.md

https://claude.ai/code/session_01TGkmjnkSJ5V6Pxa2SseZcT