### PR TITLE
fix: correct D-pad bitmask offsets (all shifted by 1)

### DIFF
--- a/scuf_envision/constants.py
+++ b/scuf_envision/constants.py
@@ -30,10 +30,10 @@ HID_BTN_MASK_OFFSET = 3
 # Each tuple: (bitmask, axis_code, value_when_set).
 # Source: OLH scufenvisionproV2W.go digital button parsing.
 HID_DPAD: list[tuple[int, int, int]] = [
-    (0x0001, ecodes.ABS_HAT0Y, -1),  # D-Up
-    (0x0002, ecodes.ABS_HAT0Y,  1),  # D-Down
-    (0x0004, ecodes.ABS_HAT0X, -1),  # D-Left
-    (0x0008, ecodes.ABS_HAT0X,  1),  # D-Right
+    (0x0002, ecodes.ABS_HAT0Y, -1),  # D-Up
+    (0x0004, ecodes.ABS_HAT0Y,  1),  # D-Down
+    (0x0008, ecodes.ABS_HAT0X, -1),  # D-Left
+    (0x0010, ecodes.ABS_HAT0X,  1),  # D-Right
 ]
 
 # 32-bit bitmask → canonical virtual button code (emitted to uinput).


### PR DESCRIPTION
Actual hardware bit positions verified from live diag output: D-Up=0x0002, D-Down=0x0004, D-Left=0x0008, D-Right=0x0010. OLH source had them at 0x0001–0x0008 (one bit low), causing Up→Down, Down→Left, Left→Right, Right→nothing.

https://claude.ai/code/session_01YUjoYnMh49skuddqALYVFc