### PR TITLE
fix: don't kill ControlReader thread on keepalive/battery write failure

### DIFF
--- a/scuf_envision/hid.py
+++ b/scuf_envision/hid.py
@@ -310,17 +310,17 @@ class ControlReader:
             if now >= next_keepalive:
                 try:
                     os.write(self._fd, _packet(self._endpoint, _CMD_KEEPALIVE))
+                    log.debug("Battery keepalive sent")
                 except OSError:
-                    break
-                log.debug("Battery keepalive sent")
+                    pass  # controller temporarily unreachable; keep looping until read fails
                 next_keepalive = now + _KEEPALIVE_INTERVAL
 
             if now >= next_battery:
                 try:
                     os.write(self._fd, _packet(self._endpoint, _CMD_BATTERY))
+                    log.info("Battery poll sent")
                 except OSError:
-                    break
-                log.info("Battery poll sent")
+                    pass  # same — skip this poll, retry next interval
                 next_battery = now + _BATTERY_INTERVAL
 
     def _parse_buttons(self, data: bytes) -> None:


### PR DESCRIPTION
When the wireless controller powers off, the USB dongle stays plugged in so the evdev fd remains valid and _DeviceDisconnected is never raised. ControlReader's keepalive write fails (controller unreachable) and broke the thread; AnalogListener only reads so it survived and resumed on reconnect — causing buttons dead, sticks fine.

Fix: swallow write OSErrors and keep looping; only break on read failure, which means the fd itself is dead (dongle unplugged). The thread naturally resumes forwarding buttons when the controller powers back on.

https://claude.ai/code/session_01YUjoYnMh49skuddqALYVFc