### PR TITLE
fix: paddle/SAX button remaps non-functional due to RGB init ack pois…

### DIFF
--- a/scuf_envision/bridge.py
+++ b/scuf_envision/bridge.py
@@ -100,8 +100,6 @@ class BridgeService:
                                               notify_thresholds=thresholds)
                 try:
                     self._control.start()
-                    self._control.set_input_callbacks(
-                        self._on_hid_button, self._on_hid_axis, self.gamepad.syn)
                 except OSError as e:
                     log.warning("Battery reader unavailable: %s", e)
                     self._control = None
@@ -125,6 +123,14 @@ class BridgeService:
                 except OSError as e:
                     log.warning("RGB unavailable: %s", e)
                     self._rgb = None
+
+            # Register input callbacks AFTER RGB init so that firmware ack packets
+            # (which can arrive on ControlReader's fd and look like button-mask
+            # packets) don't poison _btn_state before any real presses occur.
+            # set_input_callbacks() clears _btn_state on registration.
+            if self._control:
+                self._control.set_input_callbacks(
+                    self._on_hid_button, self._on_hid_axis, self.gamepad.syn)
 
             # Load profiles from config
             config = load_config()

--- a/scuf_envision/hid.py
+++ b/scuf_envision/hid.py
@@ -196,6 +196,11 @@ class ControlReader:
         self._button_cb = button_cb
         self._axis_cb = axis_cb
         self._syn_cb = syn_cb
+        # Clear any stale state accumulated during RGB init (ack packets can
+        # spuriously set paddle/SAX bits, causing missed first-press events).
+        self._btn_state.clear()
+        self._dpad_state[ecodes.ABS_HAT0X] = 0
+        self._dpad_state[ecodes.ABS_HAT0Y] = 0
 
     @property
     def level(self) -> int:


### PR DESCRIPTION
…oning

RGB init ack packets arrive on ControlReader's fd (same hidraw device) and match the button-mask packet format (data[0]==0x03, data[2]==0x02) with paddle/SAX bits set. Previously, set_input_callbacks was called before RGB init, so the callback was active when acks arrived, setting _btn_state for P1-P4/S1-S2 to True. Subsequent real presses showed no state change → no callback fire.

Fix: register callbacks after RGB init; set_input_callbacks() now clears _btn_state and _dpad_state on registration so any accumulated ack state is discarded before real input events are processed.

https://claude.ai/code/session_012CWpGbwgLMN4LJzi9q9XMo